### PR TITLE
Use Ollama for local hyperparameter tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,18 @@ We explore the use of large language models (LLMs) in hyperparameter optimizatio
 `cifar/train.py` implements our method on CIFAR-10 and can be used to reproduce the results in our paper. The provide code demonstrates how to conduct our experiments with Vision Transformers and a small ResNet. The same prompt is used for both models in our experiments to make the tuning task more difficult.
 
 ### Setup
-Set up your OpenAI API credentials. You can also modify `LLMHyperparameterTuner` to call a different LLM.
+1. Install and start [Ollama](https://ollama.com/download) on the machine running the experiments.
+2. Pull the model you would like to use for hyper-parameter tuning, for example:
 
-```
-# Set up OpenAI API credentials: https://platform.openai.com/api-keys
-export OPENAI_API_KEY=(YOUR OPENAI API KEY)
-```
+   ```
+   ollama pull llama3
+   ```
 
-Install packages.
+3. (Optional) If Ollama is hosted on a different machine or port, set the `OLLAMA_HOST`
+   environment variable, e.g. `export OLLAMA_HOST="http://my-server:11434"`.
+
+Install the Python dependencies:
+
 ```
 pip install -r requirements.txt
 ```

--- a/llm_hpo.py
+++ b/llm_hpo.py
@@ -1,14 +1,20 @@
 
 import json
-import openai
 import re
+import time
+
+from ollama_client import OllamaChatClient
 
 class LLMOptimizer:
-    def __init__(self, is_expert="generic", model="gpt-3.5-turbo",
-        temperature = 0.0,
-        max_tokens = 600,
-        frequency_penalty = 0,
-        use_cot = False,
+    def __init__(
+        self,
+        is_expert="generic",
+        model="llama3",
+        temperature=0.0,
+        max_tokens=600,
+        frequency_penalty=0.0,
+        use_cot=False,
+        base_url=None,
     ):
         self.model = model
         self.is_expert = is_expert
@@ -17,6 +23,7 @@ class LLMOptimizer:
         self.frequency_penalty = frequency_penalty
         self.use_cot = use_cot
         self.messages = []
+        self.client = OllamaChatClient(model=model, base_url=base_url)
 
         # Initialize the conversation with the given system prompt
         self.initial_config()
@@ -31,26 +38,18 @@ class LLMOptimizer:
         tries = 0
         while tries < max_retries:
             try:
-                response = openai.ChatCompletion.create(
-                    model=self.model,
-                    messages=self.messages,
+                response_text = self.client.chat(
+                    self.messages,
                     temperature=self.temperature,
-                    max_tokens=self.max_tokens,
-                    frequency_penalty=self.frequency_penalty
+                    num_predict=self.max_tokens,
+                    frequency_penalty=self.frequency_penalty,
                 )
-                # make sure we have the right version
-                if self.model == "gpt-4":
-                    assert response.model == 'gpt-4-0613'
-                elif self.model == "gpt-3.5-turbo":
-                    assert response.model == "gpt-3.5-turbo-0613"
-                config = response["choices"][0]["message"]["content"]
-                self.messages.append({"role":"assistant", "content": config})
-                return config 
+                self.messages.append({"role": "assistant", "content": response_text})
+                return response_text
             except Exception as e:
                 tries += 1
                 print(e)
-                import time; time.sleep(30)
-        print(response)
+                time.sleep(5)
         raise Exception("Failed to call LLM, max retries exceeded")
 
     def _parse_raw_message(self, raw_message):
@@ -67,13 +66,21 @@ class LLMOptimizer:
     def parse_message(self, raw_message):
         if "Output: " in raw_message:
             raw_message = raw_message.split("Output: ")[1]
+        cleaned_message = raw_message.strip()
+        fenced_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", cleaned_message, re.DOTALL)
+        if fenced_match:
+            cleaned_message = fenced_match.group(1)
         try:
-            params = json.loads(raw_message)
-            params = params["x"]
-        except:
-            print("***Raising exception...")
-            print(raw_message)
-            raise Exception("Failed to parse message")
+            params = json.loads(cleaned_message)
+        except json.JSONDecodeError:
+            json_match = re.search(r"\{.*\}", cleaned_message, re.DOTALL)
+            if json_match:
+                params = json.loads(json_match.group(0))
+            else:
+                print("***Raising exception...")
+                print(raw_message)
+                raise Exception("Failed to parse message")
+        params = params["x"]
         return params
         
     

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,0 +1,89 @@
+"""Utility helpers for interacting with a local Ollama server."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+class OllamaChatClient:
+    """Minimal client for the Ollama chat completion API.
+
+    Parameters
+    ----------
+    model:
+        Name of the Ollama model to use, e.g. ``"llama3"``.
+    base_url:
+        Base URL where the Ollama server is hosted. Defaults to the value of
+        the ``OLLAMA_HOST`` environment variable or ``"http://localhost:11434"``.
+    timeout:
+        Timeout (in seconds) for HTTP requests to the Ollama server.
+    """
+
+    def __init__(self, model: str, base_url: Optional[str] = None, timeout: int = 120) -> None:
+        self.model = model
+        self.base_url = base_url or os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+        self.timeout = timeout
+
+    def _build_options(
+        self,
+        temperature: Optional[float] = None,
+        num_predict: Optional[int] = None,
+        frequency_penalty: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        options: Dict[str, Any] = {}
+        if temperature is not None:
+            options["temperature"] = temperature
+        if num_predict is not None:
+            options["num_predict"] = num_predict
+        if frequency_penalty is not None:
+            # Ollama refers to this parameter as ``repeat_penalty``.
+            options["repeat_penalty"] = frequency_penalty
+        if seed is not None:
+            options["seed"] = seed
+        return options
+
+    def chat(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        temperature: Optional[float] = None,
+        num_predict: Optional[int] = None,
+        frequency_penalty: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> str:
+        """Call the Ollama chat API with the given conversation history.
+
+        Returns the assistant message content from the response. Raises
+        ``requests.HTTPError`` if the Ollama server responds with an error or
+        ``ValueError`` if the response payload is malformed.
+        """
+
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+        }
+        options = self._build_options(
+            temperature=temperature,
+            num_predict=num_predict,
+            frequency_penalty=frequency_penalty,
+            seed=seed,
+        )
+        if options:
+            payload["options"] = options
+
+        response = requests.post(
+            self.base_url.rstrip("/") + "/api/chat",
+            json=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data: Dict[str, Any] = response.json()
+        message = data.get("message")
+        if not message or "content" not in message:
+            raise ValueError(f"Unexpected Ollama response: {data}")
+        return message["content"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+datasets
+numpy
+matplotlib
+requests
+torch
+torchvision
+einops

--- a/run_toy_fns.ipynb
+++ b/run_toy_fns.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openai\n",
+    "import os\n",
     "from llm_hpo import LLMOptimizer\n",
     "from utils.toy_utils import *\n",
     "\n",
@@ -20,13 +20,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    openai.api_key = os.getenv(\"OPENAI_API_KEY\")\n",
-    "except:\n",
-    "    #insert key here \n",
-    "    print(\"API key not found in environment variables\")\n",
-    "    openai.api_key = \"\"\n",
-    "   "
+    "ollama_host = os.getenv(\"OLLAMA_HOST\", \"http://localhost:11434\")\n",
+    "print(f'Using Ollama host: {ollama_host}')\n"
    ]
   },
   {
@@ -68,7 +63,7 @@
     "name = \"quadratic2d\"\n",
     "t = named_toy_functions[name]\n",
     "search_budget = 5\n",
-    "llm_model = \"gpt-3.5-turbo\"\n",
+    "llm_model = \"llama3\"\n",
     "use_cot = True\n",
     "temperature = 0\n",
     "prompt_number = 2  \n",

--- a/utils/toy_utils.py
+++ b/utils/toy_utils.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-import openai
 
 from llm_hpo import LLMOptimizer
 


### PR DESCRIPTION
## Summary
- add a lightweight Ollama chat client and refactor the hyperparameter tuning pipeline to call it
- remove OpenAI-specific code from utilities/notebooks and refresh the README with Ollama setup guidance
- add a requirements.txt enumerating the Python dependencies

## Testing
- python -m compileall llm_hpo.py cifar/train.py utils/toy_utils.py ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68cf6c8d4d588325879880ef07078b2d