### PR TITLE
Improve Ollama CLI parsing and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ We explore the use of large language models (LLMs) in hyperparameter optimizatio
 `cifar/train.py` implements our method on CIFAR-10 and can be used to reproduce the results in our paper. The provide code demonstrates how to conduct our experiments with Vision Transformers and a small ResNet. The same prompt is used for both models in our experiments to make the tuning task more difficult.
 
 ### Setup
-1. Install and start [Ollama](https://ollama.com/download) on the machine running the experiments.
-2. Pull the model you would like to use for hyper-parameter tuning, for example:
+1. Install [Ollama](https://ollama.com/download) on the machine running the experiments.
+2. Ensure that the `ollama` CLI is available on your `PATH` (or set the
+   `OLLAMA_EXECUTABLE` environment variable to point to the binary).
+3. Pull the model you would like to use for hyper-parameter tuning, for example:
 
    ```
    ollama pull llama3
    ```
-
-3. (Optional) If Ollama is hosted on a different machine or port, set the `OLLAMA_HOST`
-   environment variable, e.g. `export OLLAMA_HOST="http://my-server:11434"`.
 
 Install the Python dependencies:
 

--- a/cifar/train.py
+++ b/cifar/train.py
@@ -120,12 +120,13 @@ class LLMHyperparameterTuner:
 
 def llm_hyperparameter_search(tuner, rounds=10):
     """Perform hyperparameter search using the LLM tuner."""
-    results = []  
+    results = []
     training_exception = None
     for i in range(rounds):
+        config = None
         try:
             config = tuner.suggest_hyperparameters(training_exception=training_exception)
-            validation_loss, validation_error = train_and_evaluate(config) 
+            validation_loss, validation_error = train_and_evaluate(config)
             tuner.update_configs(config, validation_error, validation_loss)
             # save and print results
             results.append({

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,50 +1,109 @@
-"""Utility helpers for interacting with a local Ollama server."""
+"""Utility helpers for interacting with a local Ollama installation."""
 
 from __future__ import annotations
 
+import json
 import os
-from typing import Any, Dict, List, Optional
-
-import requests
+import shutil
+import subprocess
+from typing import Dict, List, Optional
 
 
 class OllamaChatClient:
-    """Minimal client for the Ollama chat completion API.
+    """Minimal client for the Ollama chat completion API using the CLI.
+
+    Unlike the previous HTTP-based implementation, this version shells out to
+    the ``ollama`` command line interface. This keeps the workflow completely
+    headless and avoids the need to expose or access an HTTP endpoint.
 
     Parameters
     ----------
     model:
         Name of the Ollama model to use, e.g. ``"llama3"``.
     base_url:
-        Base URL where the Ollama server is hosted. Defaults to the value of
-        the ``OLLAMA_HOST`` environment variable or ``"http://localhost:11434"``.
+        Deprecated parameter retained for backwards compatibility. The value is
+        ignored because this client no longer communicates over HTTP.
+    executable:
+        Optional path to the ``ollama`` executable. If not provided, the value
+        of the ``OLLAMA_EXECUTABLE`` environment variable is used, falling back
+        to simply ``"ollama"``.
     timeout:
-        Timeout (in seconds) for HTTP requests to the Ollama server.
+        Timeout (in seconds) for calls to the Ollama CLI.
     """
 
-    def __init__(self, model: str, base_url: Optional[str] = None, timeout: int = 120) -> None:
+    def __init__(
+        self,
+        model: str,
+        base_url: Optional[str] = None,
+        *,
+        executable: Optional[str] = None,
+        timeout: int = 120,
+    ) -> None:
         self.model = model
-        self.base_url = base_url or os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+        if base_url is not None:
+            # For backwards compatibility we silently ignore the value but keep
+            # it around so existing callers do not break.
+            self._deprecated_base_url = base_url
+        self.executable = (
+            executable
+            or os.environ.get("OLLAMA_EXECUTABLE")
+            or "ollama"
+        )
+        if shutil.which(self.executable) is None:
+            raise FileNotFoundError(
+                "Could not find the 'ollama' executable. Set the OLLAMA_EXECUTABLE "
+                "environment variable or pass the executable path explicitly."
+            )
         self.timeout = timeout
 
+    @staticmethod
     def _build_options(
-        self,
         temperature: Optional[float] = None,
         num_predict: Optional[int] = None,
         frequency_penalty: Optional[float] = None,
         seed: Optional[int] = None,
-    ) -> Dict[str, Any]:
-        options: Dict[str, Any] = {}
+    ) -> List[str]:
+        options: List[str] = []
         if temperature is not None:
-            options["temperature"] = temperature
+            options.extend(["-o", f"temperature={temperature}"])
         if num_predict is not None:
-            options["num_predict"] = num_predict
+            options.extend(["-o", f"num_predict={num_predict}"])
         if frequency_penalty is not None:
             # Ollama refers to this parameter as ``repeat_penalty``.
-            options["repeat_penalty"] = frequency_penalty
+            options.extend(["-o", f"repeat_penalty={frequency_penalty}"])
         if seed is not None:
-            options["seed"] = seed
+            options.extend(["-o", f"seed={seed}"])
         return options
+
+    @staticmethod
+    def _extract_system_prompt(messages: List[Dict[str, str]]) -> Optional[str]:
+        """Return the content of the first system message, if any."""
+
+        for message in messages:
+            if message.get("role") == "system":
+                content = message.get("content", "")
+                if content:
+                    return content
+        return None
+
+    @staticmethod
+    def _format_messages(messages: List[Dict[str, str]]) -> str:
+        """Format chat messages into a single prompt for the CLI."""
+
+        formatted_segments: List[str] = []
+        for message in messages:
+            role = message.get("role", "user")
+            if role == "system":
+                # The system prompt is passed separately to the CLI.
+                continue
+            content = message.get("content", "")
+            if not content:
+                continue
+            role_heading = role.capitalize()
+            formatted_segments.append(f"{role_heading}: {content}")
+        # Encourage the model to respond as the assistant.
+        formatted_segments.append("Assistant:")
+        return "\n".join(formatted_segments)
 
     def chat(
         self,
@@ -55,35 +114,71 @@ class OllamaChatClient:
         frequency_penalty: Optional[float] = None,
         seed: Optional[int] = None,
     ) -> str:
-        """Call the Ollama chat API with the given conversation history.
+        """Call the Ollama CLI with the given conversation history."""
 
-        Returns the assistant message content from the response. Raises
-        ``requests.HTTPError`` if the Ollama server responds with an error or
-        ``ValueError`` if the response payload is malformed.
-        """
+        prompt = self._format_messages(messages)
+        if not prompt.strip():
+            raise ValueError("No content provided in messages for Ollama prompt.")
 
-        payload: Dict[str, Any] = {
-            "model": self.model,
-            "messages": messages,
-            "stream": False,
-        }
-        options = self._build_options(
+        cmd = [self.executable, "run", self.model, "--json"]
+        system_prompt = self._extract_system_prompt(messages)
+        if system_prompt:
+            cmd.extend(["--system", system_prompt])
+        cmd.extend(self._build_options(
             temperature=temperature,
             num_predict=num_predict,
             frequency_penalty=frequency_penalty,
             seed=seed,
-        )
-        if options:
-            payload["options"] = options
+        ))
 
-        response = requests.post(
-            self.base_url.rstrip("/") + "/api/chat",
-            json=payload,
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        data: Dict[str, Any] = response.json()
-        message = data.get("message")
-        if not message or "content" not in message:
-            raise ValueError(f"Unexpected Ollama response: {data}")
-        return message["content"]
+        try:
+            process = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                input=prompt,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"Ollama command failed with exit code {exc.returncode}: {exc.stderr.strip()}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError("Timed out waiting for Ollama CLI response") from exc
+
+        stdout = process.stdout.strip()
+        if not stdout:
+            raise ValueError("Received empty response from Ollama CLI")
+
+        response_chunks: List[str] = []
+        for line in stdout.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError:
+                # Ignore non-JSON lines to be resilient to unexpected output.
+                continue
+
+            if payload.get("error"):
+                raise RuntimeError(f"Ollama reported an error: {payload['error']}")
+
+            if "response" in payload:
+                response_chunks.append(payload["response"])
+
+            if payload.get("done"):
+                # Some models include the final assistant message under
+                # ``message`` when ``--json`` is used; capture it if present.
+                message = payload.get("message")
+                if isinstance(message, dict) and message.get("content"):
+                    response_chunks.append(message["content"])
+                break
+
+        result = "".join(response_chunks).strip()
+        if not result:
+            raise ValueError(
+                f"Unexpected Ollama response format: {json.dumps(stdout)}"
+            )
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 datasets
 numpy
 matplotlib
-requests
 torch
 torchvision
 einops


### PR DESCRIPTION
## Summary
- stream and assemble responses from `ollama run --json`, preserving the system prompt via the CLI flag and returning the aggregated assistant content
- ignore non-JSON CLI output, surface Ollama-side errors, and send prompts via stdin for better compatibility
- initialise the `config` variable during LLM tuning rounds to avoid `UnboundLocalError` when suggestions fail

## Testing
- python -m compileall cifar ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d0a64618b48325bf43c6c48568d1c5